### PR TITLE
array() -> []

### DIFF
--- a/src/Migration/Adapter/Generator/PhinxMySqlGenerator.php
+++ b/src/Migration/Adapter/Generator/PhinxMySqlGenerator.php
@@ -653,7 +653,7 @@ class PhinxMySqlGenerator
         // update set an action to be triggered when the row is updated
         // delete set an action to be triggered when the row is deleted
 
-        $result = 'array(' . implode(', ', $attributes) . ')';
+        $result = '[' . implode(', ', $attributes) . ']';
         return $result;
     }
 
@@ -812,7 +812,7 @@ class PhinxMySqlGenerator
                 $values[$k] = "'" . addcslashes($value, "'") . "'";
             }
             $valueList = implode(',', array_values($values));
-            $arr = sprintf('array(%s)', $valueList);
+            $arr = sprintf('[%s]', $valueList);
             $result = sprintf('\'values\' => %s', $arr);
             return $result;
         }
@@ -917,7 +917,7 @@ class PhinxMySqlGenerator
         foreach ($indexSequences as $indexData) {
             $indexFields[] = $indexData['Column_name'];
         }
-        $result = "array('" . implode("','", $indexFields) . "')";
+        $result = "['" . implode("','", $indexFields) . "']";
         return $result;
     }
 
@@ -943,7 +943,7 @@ class PhinxMySqlGenerator
         if (isset($indexData['INDEX_TYPE']) && $indexData['INDEX_TYPE'] == 'FULLTEXT') {
             $options[] = '\'type\' => \'fulltext\'';
         }
-        $result = 'array(' . implode(', ', $options) . ')';
+        $result = '[' . implode(', ', $options) . ']';
         return $result;
     }
 
@@ -1002,7 +1002,7 @@ class PhinxMySqlGenerator
         if (isset($fkData['delete_rule'])) {
             $options[] = '\'delete\' => "' . $this->getForeignKeyRuleValue($fkData['DELETE_RULE']) . '"';
         }
-        $result = 'array(' . implode(', ', $options) . ')';
+        $result = '[' . implode(', ', $options) . ']';
         return $result;
     }
 

--- a/tests/diffs/newtable_expected.php
+++ b/tests/diffs/newtable_expected.php
@@ -11,9 +11,9 @@ class MyNewMigration extends AbstractMigration
         $this->execute("ALTER TABLE `newtable` ENGINE='InnoDB';");
         $this->execute("ALTER TABLE `newtable` COMMENT='';");
         if ($this->table('newtable')->hasColumn('id')) {
-            $this->table("newtable")->changeColumn('id', 'integer', array('null' => false, 'limit' => MysqlAdapter::INT_REGULAR, 'precision' => 10, 'identity' => 'enable'))->update();
+            $this->table("newtable")->changeColumn('id', 'integer', ['null' => false, 'limit' => MysqlAdapter::INT_REGULAR, 'precision' => 10, 'identity' => 'enable'])->update();
         } else {
-            $this->table("newtable")->addColumn('id', 'integer', array('null' => false, 'limit' => MysqlAdapter::INT_REGULAR, 'precision' => 10, 'identity' => 'enable'))->update();
+            $this->table("newtable")->addColumn('id', 'integer', ['null' => false, 'limit' => MysqlAdapter::INT_REGULAR, 'precision' => 10, 'identity' => 'enable'])->update();
         }
     }
 }


### PR DESCRIPTION
Shortcodes has been introduced in PHP5.4 which is not supported by composer.json, there's no reason to use it in migration. It can help read the code a bit.