### PR TITLE
Add save after each table addColumn to fix change column errors

### DIFF
--- a/src/Migration/Adapter/Generator/PhinxMySqlGenerator.php
+++ b/src/Migration/Adapter/Generator/PhinxMySqlGenerator.php
@@ -1016,7 +1016,7 @@ class PhinxMySqlGenerator
     {
         $result = $this->getColumnCreate($schema, $table, $columnName);
 
-        return sprintf("%s\$table->addColumn('%s', '%s', %s);", $this->ind2, $result[1], $result[2], $result[3]);
+        return sprintf("%s\$table->addColumn('%s', '%s', %s)->save();", $this->ind2, $result[1], $result[2], $result[3]);
     }
 
     /**


### PR DESCRIPTION
I had this migration created (mock data).
```
        $this->execute("SET UNIQUE_CHECKS = 0;");
        $this->execute("SET FOREIGN_KEY_CHECKS = 0;");
        $table = $this->table("TABLE");
        $table->addColumn('NEW_COLUMN', 'integer', ['null' => false, 'default' => "0", 'limit' => MysqlAdapter::INT_REGULAR, 'precision' => 10, 'after' => 'EXISTING_COLUMN_A']);
        $this->table("TABLE")->changeColumn('EXISTING_COLUMN_B', 'datetime', ['null' => false, 'after' => 'NEW_COLUMN'])->update();
        $table->save();
        $this->execute("SET FOREIGN_KEY_CHECKS = 1;");
        $this->execute("SET UNIQUE_CHECKS = 1;");
```

And it produced the error `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'NEW_COLUMN' in 'TABLE'`.  
And this was happening because the column wasnt being saved before setting **after** with the same column.
Now it will append `save()` after each table add column.