### PR TITLE
Make database adapter configurable

### DIFF
--- a/src/Migration/Adapter/Database/MySqlAdapter.php
+++ b/src/Migration/Adapter/Database/MySqlAdapter.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * MySqlAdapter.
  */
-class MySqlAdapter
+class MySqlAdapter implements SchemaAdapterInterface
 {
     /**
      * PDO.

--- a/src/Migration/Adapter/Database/SchemaAdapterInterface.php
+++ b/src/Migration/Adapter/Database/SchemaAdapterInterface.php
@@ -1,0 +1,47 @@
+<?php
+namespace Odan\Migration\Adapter\Database;
+
+/**
+ * Interface for all Database adapters
+ *
+ */
+interface SchemaAdapterInterface
+{
+
+    /**
+     * Load current database schema.
+     *
+     * @return array
+     */
+    public function getSchema(): array;
+
+    /**
+     * Quote value.
+     *
+     * @param string|null $value
+     *
+     * @return string
+     */
+    public function quote($value): string;
+
+    /**
+     * Escape identifier (column, table) with backtick.
+     *
+     * @see: http://dev.mysql.com/doc/refman/5.0/en/identifiers.html
+     *
+     * @param string $value
+     * @param string $quote
+     *
+     * @return string identifier escaped string
+     */
+    public function ident($value, $quote = '`'): string;
+
+    /**
+     * Get foreign keys.
+     *
+     * @param string $tableName
+     *
+     * @return array|null
+     */
+    public function getForeignKeys($tableName): ?array;
+}

--- a/src/Migration/Adapter/Generator/PhinxMySqlGenerator.php
+++ b/src/Migration/Adapter/Generator/PhinxMySqlGenerator.php
@@ -2,7 +2,7 @@
 
 namespace Odan\Migration\Adapter\Generator;
 
-use Odan\Migration\Adapter\Database\MySqlAdapter;
+use Odan\Migration\Adapter\Database\SchemaAdapterInterface;
 use Phinx\Db\Adapter\AdapterInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -14,7 +14,7 @@ class PhinxMySqlGenerator
     /**
      * Database adapter.
      *
-     * @var MySqlAdapter
+     * @var SchemaAdapterInterface
      */
     protected $dba;
 
@@ -55,11 +55,11 @@ class PhinxMySqlGenerator
     /**
      * Constructor.
      *
-     * @param MySqlAdapter $dba
+     * @param SchemaAdapterInterface $dba
      * @param OutputInterface $output
      * @param mixed $options Options
      */
-    public function __construct(MySqlAdapter $dba, OutputInterface $output, $options = [])
+    public function __construct(SchemaAdapterInterface $dba, OutputInterface $output, $options = [])
     {
         $this->dba = $dba;
         $this->output = $output;

--- a/src/Migration/Command/GenerateCommand.php
+++ b/src/Migration/Command/GenerateCommand.php
@@ -129,7 +129,8 @@ class GenerateCommand extends AbstractCommand
             'default_migration_table' => $defaultMigrationTable,
         ];
 
-        $generator = new MigrationGenerator($settings, $input, $output);
+        $dba = new \Odan\Migration\Adapter\Database\MySqlAdapter($pdo, $output);
+        $generator = new MigrationGenerator($settings, $input, $output, $dba);
 
         return $generator->generate();
     }

--- a/src/Migration/Generator/MigrationGenerator.php
+++ b/src/Migration/Generator/MigrationGenerator.php
@@ -5,8 +5,10 @@ namespace Odan\Migration\Generator;
 use Exception;
 use InvalidArgumentException;
 use Odan\Migration\Adapter\Database\MySqlAdapter;
+use Odan\Migration\Adapter\Database\SchemaAdapterInterface;
 use Odan\Migration\Adapter\Generator\PhinxMySqlGenerator;
 use PDO;
+use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Util\Util;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -79,12 +81,13 @@ class MigrationGenerator
      * @param array $settings
      * @param InputInterface $input
      * @param OutputInterface $output
+     * @param SchemaAdapterInterface $dba
      */
-    public function __construct(array $settings, InputInterface $input, OutputInterface $output)
+    public function __construct(array $settings, InputInterface $input, OutputInterface $output, SchemaAdapterInterface $dba)
     {
         $this->settings = $settings;
         $this->pdo = $this->getPdo($settings);
-        $this->dba = new MySqlAdapter($this->pdo, $output);
+        $this->dba = $dba;
         $this->generator = new PhinxMySqlGenerator($this->dba, $output, $settings);
         $this->output = $output;
         $this->input = $input;
@@ -358,7 +361,7 @@ class MigrationGenerator
     {
         $this->output->writeln('Mark migration');
 
-        /* @var $adapter \Phinx\Db\Adapter\AdapterInterface */
+        /* @var $adapter AdapterInterface */
         $adapter = $this->settings['adapter'];
 
         $schemaTableName = $this->settings['default_migration_table'];


### PR DESCRIPTION
Hi!

I want to supply the schema not from the database, but from my models. To make this possible I've put all externally called methods of `Odan\Migration\Adapter\Database\MySqlAdapter` into an interface and injected that interface into `Odan\Migration\Generator\MigrationGenerator`. That way I can write my own command using my own adapter.