### PR TITLE
Base class for generated migration from phinx config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ The phinx-migrations-generator uses the configuration of phinx.
 Parameter | Values | Default | Description
 --- | --- | --- | ---
 foreign_keys | bool | false | Enable or disable foreign key migrations.
+mark_generated_migration | bool | true | Enable or disable marking the migration as applied after creation.
+migration_base_class | string | 'Phinx\Migration\AbstractMigration' | Sets up base class of created migration.
 
 ### Example configuration
 
@@ -103,6 +105,8 @@ return [
         'migrations' => $migrationPath,
     ],
     'foreign_keys' => false,
+    'mark_generated_migration' => true,
+    'migration_base_class' => \Phinx\Migration\AbstractMigration::class,
     'environments' => [
         'default_database' => 'local',
         'local' => [

--- a/src/Migration/Adapter/Generator/PhinxMySqlGenerator.php
+++ b/src/Migration/Adapter/Generator/PhinxMySqlGenerator.php
@@ -87,13 +87,14 @@ class PhinxMySqlGenerator
      */
     public function createMigration($name, $newSchema, $oldSchema): string
     {
+        $className = $this->options['migration_base_class'] ?? 'Phinx\Migration\AbstractMigration';
+
         $output = [];
         $output[] = '<?php';
         $output[] = '';
-        $output[] = 'use Phinx\Migration\AbstractMigration;';
         $output[] = 'use Phinx\Db\Adapter\MysqlAdapter;';
         $output[] = '';
-        $output[] = sprintf('class %s extends AbstractMigration', $name);
+        $output[] = sprintf('class %s extends ' . $className, $name);
         $output[] = '{';
         $output = $this->addChangeMethod($output, $newSchema, $oldSchema);
         $output[] = '}';

--- a/src/Migration/Command/GenerateCommand.php
+++ b/src/Migration/Command/GenerateCommand.php
@@ -128,6 +128,7 @@ class GenerateCommand extends AbstractCommand
         $pdo = $this->getPdo($manager, $environment);
 
         $foreignKeys = $config->offsetExists('foreign_keys') ? $config->offsetGet('foreign_keys') : false;
+        $markMigration = $config->offsetExists('mark_generated_migration') ? $config->offsetGet('mark_generated_migration') : true;
 
         $defaultMigrationTable = $envOptions['default_migration_table'] ?? 'phinxlog';
 
@@ -145,8 +146,9 @@ class GenerateCommand extends AbstractCommand
             'config_file' => $configFilePath,
             'name' => $name,
             'overwrite' => $overwrite,
-            'mark_migration' => true,
+            'mark_migration' => $markMigration,
             'default_migration_table' => $defaultMigrationTable,
+            'migration_base_class' => $config->getMigrationBaseClassName(false),
         ];
 
         $dba = new MySqlSchemaAdapter($pdo, $output);

--- a/tests/diffs/newtable_expected.php
+++ b/tests/diffs/newtable_expected.php
@@ -1,9 +1,8 @@
 <?php
 
-use Phinx\Migration\AbstractMigration;
 use Phinx\Db\Adapter\MysqlAdapter;
 
-class MyNewMigration extends AbstractMigration
+class MyNewMigration extends Phinx\Migration\AbstractMigration
 {
     public function change()
     {


### PR DESCRIPTION
The Phinx configuration file contains parameter "migration_base_class" (http://docs.phinx.org/en/latest/configuration.html#custom-migration-base). Now it will be applied to the generator as well - created migrations will be inherited from the specified class.

I would also suggest configuring the "mark_migration" option.