### PR TITLE
Ability to generate a random name with some prefix for the created migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The phinx-migrations-generator uses the configuration of phinx.
 Parameter | Values | Default | Description
 --- | --- | --- | ---
 foreign_keys | bool | false | Enable or disable foreign key migrations.
+default_migration_prefix | string | null | If specified, in the absence of the name parameter, the default migration name will be offered with this prefix and a random hash at the end.
 
 ### Example configuration
 
@@ -103,6 +104,7 @@ return [
         'migrations' => $migrationPath,
     ],
     'foreign_keys' => false,
+    'default_migration_prefix' => 'db_change_',
     'environments' => [
         'default_database' => 'local',
         'local' => [

--- a/src/Migration/Command/GenerateCommand.php
+++ b/src/Migration/Command/GenerateCommand.php
@@ -128,6 +128,7 @@ class GenerateCommand extends AbstractCommand
         $pdo = $this->getPdo($manager, $environment);
 
         $foreignKeys = $config->offsetExists('foreign_keys') ? $config->offsetGet('foreign_keys') : false;
+        $defaultMigrationPrefix = $config->offsetExists('default_migration_prefix') ? $config->offsetGet('default_migration_prefix') : null;
 
         $defaultMigrationTable = $envOptions['default_migration_table'] ?? 'phinxlog';
 
@@ -147,6 +148,7 @@ class GenerateCommand extends AbstractCommand
             'overwrite' => $overwrite,
             'mark_migration' => true,
             'default_migration_table' => $defaultMigrationTable,
+            'default_migration_prefix' => $defaultMigrationPrefix,
         ];
 
         $dba = new MySqlSchemaAdapter($pdo, $output);

--- a/src/Migration/Generator/MigrationGenerator.php
+++ b/src/Migration/Generator/MigrationGenerator.php
@@ -121,6 +121,20 @@ class MigrationGenerator
     }
 
     /**
+     * Generates random name, based on "default_migration_prefix" setting.
+     *
+     * @return string
+     */
+    protected function generateDefaultMigrationName(): string
+    {
+        if (isset($this->settings['default_migration_prefix'])) {
+            return $this->settings['default_migration_prefix'] . uniqid(mt_rand(), false);
+        }
+        
+        return '';
+    }
+    
+    /**
      * Generate.
      *
      * @throws Exception
@@ -140,7 +154,8 @@ class MigrationGenerator
         }
 
         if (empty($this->settings['name'])) {
-            $name = $this->io->ask('Enter migration name', '');
+            $defaultMigrationName = $this->generateDefaultMigrationName();
+            $name = $this->io->ask('Enter migration name', $defaultMigrationName);
         } else {
             $name = $this->settings['name'];
         }

--- a/src/Migration/Generator/MigrationGenerator.php
+++ b/src/Migration/Generator/MigrationGenerator.php
@@ -128,7 +128,7 @@ class MigrationGenerator
     protected function generateDefaultMigrationName(): string
     {
         if (isset($this->settings['default_migration_prefix'])) {
-            return $this->settings['default_migration_prefix'] . uniqid(mt_rand(), false);
+            return $this->settings['default_migration_prefix'] . uniqid((string) mt_rand(), false);
         }
         
         return '';


### PR DESCRIPTION
By default user is prompted to enter a migration name if it's not specified by the parameter. If it is difficult to come up with unique names for new migrations, or we have plenty of them, it's more convenient to generate a random name and offer it by default. If the option "default_migration_prefix" is specified in the config, a name will be offered starting with this line and ending with a random hash. Otherwise, current behavior will not change.