### PR TITLE
Fast load of database schema

### DIFF
--- a/src/Migration/Adapter/Database/MySqlSchemaAdapter.php
+++ b/src/Migration/Adapter/Database/MySqlSchemaAdapter.php
@@ -9,7 +9,7 @@ use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * MySqlAdapter.
+ * MySqlSchemaAdapter.
  */
 class MySqlSchemaAdapter implements SchemaAdapterInterface
 {
@@ -108,15 +108,21 @@ class MySqlSchemaAdapter implements SchemaAdapterInterface
 
         $result['database'] = $this->getDatabaseSchemata($this->dbName);
 
+        // processing by chunks for better speed when we have hundreds of tables
         $tables = $this->getTables();
 
-        foreach ($tables as $table) {
-            $tableName = $table['table_name'];
-            $this->output->writeln(sprintf('Table: <info>%s</info>', $tableName));
-            $result['tables'][$tableName]['table'] = $table;
-            $result['tables'][$tableName]['columns'] = $this->getColumns($tableName);
-            $result['tables'][$tableName]['indexes'] = $this->getIndexes($tableName);
-            $result['tables'][$tableName]['foreign_keys'] = $this->getForeignKeys($tableName);
+        $tableNameChunks = array_chunk(array_column($tables, 'table_name'), 300);
+        foreach ($tableNameChunks as $tablesInChunk) {
+            $columns = $this->getColumnHash($tablesInChunk);
+            $indexes = $this->getIndexHash($tablesInChunk);
+            $foreign_keys = $this->getForeignKeysHash($tablesInChunk);
+            foreach ($tablesInChunk as $tableName) {
+                $this->output->writeln(sprintf('Table: <info>%s</info>', $tableName), OutputInterface::VERBOSITY_VERBOSE);
+                $result['tables'][$tableName]['table'] = $tables[$tableName];
+                $result['tables'][$tableName]['columns'] = $columns[$tableName] ?? [];
+                $result['tables'][$tableName]['indexes'] = $indexes[$tableName] ?? [];
+                $result['tables'][$tableName]['foreign_keys'] = $foreign_keys[$tableName] ?? null;
+            }
         }
 
         $array = new ArrayUtil();
@@ -162,6 +168,20 @@ class MySqlSchemaAdapter implements SchemaAdapterInterface
     }
 
     /**
+     * Quote array of values.
+     *
+     * @param array|string|null $values
+     *
+     * @return string[]
+     */
+    public function quoteArray($values)
+    {
+        return array_map(function ($value) {
+            return $this->quote($value);
+        }, (array) $values);
+    }
+
+    /**
      * Get all tables.
      *
      * @return array
@@ -181,7 +201,7 @@ class MySqlSchemaAdapter implements SchemaAdapterInterface
         $rows = $this->queryFetchAll($sql);
 
         foreach ($rows as $row) {
-            $result[] = [
+            $result[$row['TABLE_NAME']] = [
                 'table_name' => $row['TABLE_NAME'],
                 'engine' => $row['ENGINE'],
                 'table_comment' => $row['TABLE_COMMENT'],
@@ -203,16 +223,35 @@ class MySqlSchemaAdapter implements SchemaAdapterInterface
      */
     protected function getColumns($tableName): array
     {
+        $rows = $this->getColumnHash([$tableName]);
+        return $rows[$tableName] ?? [];
+    }
+
+    /**
+     * Get columns, grouped by table name.
+     *
+     * @param array $tableNames
+     *
+     * @return array[]
+     */
+    protected function getColumnHash(array $tableNames)
+    {
+        if (empty($tableNames)) {
+            return [];
+        }
+        
+        $quotedNames = $this->quoteArray($tableNames);
         $sql = sprintf('SELECT * FROM information_schema.columns
                     WHERE table_schema=database()
-                    AND table_name = %s', $this->quote($tableName));
+                    AND table_name in (%s)', implode(',', $quotedNames));
 
         $rows = $this->queryFetchAll($sql);
 
         $result = [];
         foreach ($rows as $row) {
-            $name = $row['COLUMN_NAME'];
-            $result[$name] = $row;
+            $table_name = $row['TABLE_NAME'];
+            $column_name = $row['COLUMN_NAME'];
+            $result[$table_name][$column_name] = $row;
         }
 
         return $result;
@@ -227,16 +266,47 @@ class MySqlSchemaAdapter implements SchemaAdapterInterface
      */
     protected function getIndexes($tableName): array
     {
-        $sql = sprintf('SHOW INDEX FROM %s', $this->ident($tableName));
+        $rows = $this->getIndexHash([$tableName]);
+        return $rows[$tableName] ?? [];
+    }
+
+    /**
+     * Get indexes, grouped by table name.
+     *
+     * @param array $tableNames
+     *
+     * @return array
+     */
+    protected function getIndexHash($tableNames)
+    {
+        if (empty($tableNames)) {
+            return [];
+        }
+        
+        $quotedNames = $this->quoteArray($tableNames);
+        $sql = sprintf("SELECT 
+                `TABLE_NAME` as 'Table',
+                `NON_UNIQUE` as 'Non_unique',
+                `INDEX_NAME` as 'Key_name',
+                `SEQ_IN_INDEX` as 'Seq_in_index',
+                `COLUMN_NAME` as 'Column_name',
+                `COLLATION` as 'Collation',
+                `SUB_PART` as 'Sub_part',
+                `PACKED` as 'Packed',
+                `NULLABLE` as 'Null',
+                `INDEX_TYPE` as 'Index_type',
+                `COMMENT` as 'Comment',
+                `INDEX_COMMENT` as 'Index_comment'
+                FROM information_schema.statistics
+                    WHERE table_schema=database()
+                    AND table_name in (%s)", implode(',', $quotedNames));
         $rows = $this->queryFetchAll($sql);
         $result = [];
         foreach ($rows as $row) {
-            if (isset($row['Cardinality'])) {
-                unset($row['Cardinality']);
-            }
+            $tableName = $row['Table'];
             $name = $row['Key_name'];
             $seq = $row['Seq_in_index'];
-            $result[$name][$seq] = $row;
+            $result[$tableName][$name][$seq] = $row;
         }
 
         return $result;
@@ -248,12 +318,12 @@ class MySqlSchemaAdapter implements SchemaAdapterInterface
      * @see: http://dev.mysql.com/doc/refman/5.0/en/identifiers.html
      *
      * @param string $value
+     * @param string $quote
      *
      * @return string identifier escaped string
      */
-    public function ident(string $value): string
+    public function ident(string $value, $quote = '`'): string
     {
-        $quote = '`';
         $value = preg_replace('/[^A-Za-z0-9_\.]+/', '', $value);
         $value = is_scalar($value) ? (string)$value : '';
 
@@ -276,6 +346,24 @@ class MySqlSchemaAdapter implements SchemaAdapterInterface
      */
     protected function getForeignKeys(string $tableName): ?array
     {
+        $rows = $this->getForeignKeysHash([$tableName]);
+        return $rows[$tableName] ?? [];
+    }
+
+    /**
+     * Get foreign keys, grouped by table name.
+     *
+     * @param array $tableNames
+     *
+     * @return array|null
+     */
+    protected function getForeignKeysHash($tableNames)
+    {
+        if (empty($tableNames)) {
+            return [];
+        }
+        
+        $quotedNames = $this->quoteArray($tableNames);
         $sql = sprintf("SELECT
                 cols.TABLE_NAME,
                 cols.COLUMN_NAME,
@@ -298,11 +386,11 @@ class MySqlSchemaAdapter implements SchemaAdapterInterface
                 ON cRefs.CONSTRAINT_SCHEMA=cols.TABLE_SCHEMA
                 AND cRefs.CONSTRAINT_NAME=refs.CONSTRAINT_NAME
             WHERE
-                cols.TABLE_NAME = %s
+                cols.TABLE_NAME in (%s)
                 AND cols.TABLE_SCHEMA = DATABASE()
                 AND refs.REFERENCED_TABLE_NAME IS NOT NULL
                 AND cons.CONSTRAINT_TYPE = 'FOREIGN KEY'
-            ;", $this->quote($tableName));
+            ;", implode(',', $quotedNames));
 
         $rows = $this->queryFetchAll($sql);
 
@@ -312,7 +400,7 @@ class MySqlSchemaAdapter implements SchemaAdapterInterface
 
         $result = [];
         foreach ($rows as $row) {
-            $result[$row['CONSTRAINT_NAME']] = $row;
+            $result[$row['TABLE_NAME']][$row['CONSTRAINT_NAME']] = $row;
         }
 
         return $result;

--- a/src/Migration/Adapter/Database/SchemaAdapterInterface.php
+++ b/src/Migration/Adapter/Database/SchemaAdapterInterface.php
@@ -10,9 +10,11 @@ interface SchemaAdapterInterface
     /**
      * Load current database schema.
      *
+     * @param array|null $tableNames
+     *
      * @return array
      */
-    public function getSchema(): array;
+    public function getSchema($tableNames = null): array;
 
     /**
      * Quote value.


### PR DESCRIPTION
When the number of tables in the database is too large, the generator produces thousands of queries (literally), and since the requests for obtaining the schema are not the fastest, it can do this for very long time. I work with databases containing several hundred tables, and it is simply impossible to use the generator in its original form.

Now the schema is obtained in batches of 300 tables, which significantly reduces number of queries. On my machine, this speeds up schema generation by about 100 times. And it will not consume too much memory as it could be if we did not limit the number of tables to a specific number.

Other important change is an ability to get schema only for set of particular tables. This is used by me (and can be used by others) to process only a small number of tables in some cases.