### PR TITLE
Refactoring for better extensibility

### DIFF
--- a/src/Migration/Command/GenerateCommand.php
+++ b/src/Migration/Command/GenerateCommand.php
@@ -102,13 +102,13 @@ class GenerateCommand extends AbstractCommand
     }
 
     /**
-     * @param string $adapter_name
+     * @param string $adapterName
      *
      * @return bool true if adapter with specified name is supported
      */
-    protected function isAdapterSupported($adapter_name)
+    protected function isAdapterSupported(string $adapterName): bool
     {
-        return $adapter_name === 'mysql';
+        return $adapterName === 'mysql';
     }
 
     /**
@@ -116,7 +116,7 @@ class GenerateCommand extends AbstractCommand
      *
      * @return string Schema file path
      */
-    protected function getSchemaFilePath($migrationsPath)
+    protected function getSchemaFilePath(string $migrationsPath): string
     {
         return $migrationsPath . DIRECTORY_SEPARATOR . 'schema.php';
     }
@@ -131,7 +131,7 @@ class GenerateCommand extends AbstractCommand
      *
      * @return MigrationGenerator
      */
-    protected function getMigrationGenerator(array $settings, InputInterface $input, OutputInterface $output, $environment)
+    protected function getMigrationGenerator(array $settings, InputInterface $input, OutputInterface $output, string $environment): MigrationGenerator
     {
         $manager = $this->getManager();
         
@@ -153,7 +153,7 @@ class GenerateCommand extends AbstractCommand
      *
      * @return SchemaAdapterInterface
      */
-    protected function getSchemaAdapter(PDO $pdo, OutputInterface $output)
+    protected function getSchemaAdapter(PDO $pdo, OutputInterface $output): SchemaAdapterInterface
     {
         return new MySqlSchemaAdapter($pdo, $output);
     }
@@ -162,13 +162,12 @@ class GenerateCommand extends AbstractCommand
      * Get settings array
      *
      * @param InputInterface $input
-     * @param OutputInterface $input
      * @param string $environment
      * @return array
      *
      * @throws Exception On error
      */
-    protected function getGeneratorSettings(InputInterface $input, $environment)
+    protected function getGeneratorSettings(InputInterface $input, string $environment): array
     {
         $envOptions = $this->getConfig()->getEnvironment($environment);
         
@@ -241,7 +240,7 @@ class GenerateCommand extends AbstractCommand
      *
      * @return PDO PDO object
      */
-    protected function getPdo(Manager $manager, $environment): PDO
+    protected function getPdo(Manager $manager, string $environment): PDO
     {
         /* @var AdapterWrapper $dbAdapter */
         $dbAdapter = $manager->getEnvironment($environment)->getAdapter();

--- a/src/Migration/Generator/MigrationGenerator.php
+++ b/src/Migration/Generator/MigrationGenerator.php
@@ -121,6 +121,16 @@ class MigrationGenerator
     }
 
     /**
+     * Load current database schema.
+     *
+     * @return array
+     */
+    public function getSchema()
+    {
+        return $this->dba->getSchema();
+    }
+
+    /**
      * Generate.
      *
      * @throws Exception
@@ -129,7 +139,7 @@ class MigrationGenerator
      */
     public function generate(): int
     {
-        $schema = $this->dba->getSchema();
+        $schema = $this->getSchema();
         $oldSchema = $this->getOldSchema($this->settings);
         $diffs = $this->compareSchema($schema, $oldSchema);
 


### PR DESCRIPTION
Just plain refactoring without functionality changes. In my code I inherit the MigrationGenerator class and override some of its behavior. To do this, I put out into separate methods the pieces of code that were contained within other large methods. Also it looks a bit cleaner.