### PR TITLE
fix "Duplicate key name" error. Add drop before create in case that index h…

### DIFF
--- a/src/Migration/Adapter/Generator/PhinxMySqlGenerator.php
+++ b/src/Migration/Adapter/Generator/PhinxMySqlGenerator.php
@@ -1052,6 +1052,9 @@ final class PhinxMySqlGenerator
             if (!isset($old['tables'][$tableName]['indexes'][$indexName])) {
                 $output = $this->getIndexCreate($output, $new, $tableName, $indexName);
             } elseif ($this->neq($new, $old, ['tables', $tableName, 'indexes', $indexName])) {
+                if ($indexName !== 'PRIMARY') {
+                    $output = $this->getIndexRemove($indexName, $output);
+                }
                 $output = $this->getIndexCreate($output, $new, $tableName, $indexName);
             }
         }


### PR DESCRIPTION
If index has changed(for example index_type) then migation will contains addIndex() which cause "Duplicate key name" error, this change adds removeIndexByName() before addIndex() 