### PR TITLE
Polyfill for all PHP functions are not needed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "riimu/kit-phpencoder": "^2.4",
         "robmorgan/phinx": "^0.12",
         "symfony/console": "^2.8 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/polyfill": "^1.18"
+        "symfony/polyfill-php73": "^1.18"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",


### PR DESCRIPTION
You added `symfony/polyfill` dependency for #88, but we only need a polyfill for `array_key_first` function. We can just require `symfony/polyfill-php73`. By doing so, projects download only polyfill for one version of PHP, and only for the function we require.

For information, from `symfony/polyfill` README file, we got :

> When using Composer to manage your dependencies, you should not require the symfony/polyfill package, but the standalone ones

> Requiring `symfony/polyfill` directly would prevent Composer from sharing correctly polyfills in dependency graphs. As such, it would likely install more code than required.